### PR TITLE
Prevent language menu clipping

### DIFF
--- a/Simpler/Base.lproj/Main.storyboard
+++ b/Simpler/Base.lproj/Main.storyboard
@@ -722,7 +722,7 @@
                                 <rect key="frame" x="410" y="10" width="70" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="AJk-M3-bDl"/>
-                                    <constraint firstAttribute="width" constant="70" id="jDy-1F-a9t"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="jDy-1F-a9t"/>
                                 </constraints>
                                 <popUpButtonCell key="cell" type="bevel" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" imageScaling="proportionallyDown" inset="2" arrowPosition="noArrow" preferredEdge="maxY" id="bxw-s5-ry5">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>


### PR DESCRIPTION
Allows the language menu to grow in order to prevent clipping. You can see the clipping after selecting "Hemingway"

![clipping](https://cloud.githubusercontent.com/assets/915431/14293535/e02db6fa-fb21-11e5-97a0-f0717bbed51d.png)
