### PR TITLE
Crash fix when changing languages

### DIFF
--- a/Simpler/C.swift
+++ b/Simpler/C.swift
@@ -56,8 +56,8 @@ class C: NSObject {
         Language(code: "русский", name: "русский"),
         Language(code: "Trump", name: "Trump"),
         Language(code: "xkcd", name: "xkcd"),
-        Language(code: "jobs", name: "jobs"),
-        Language(code: "hemingway", name: "hemingway"),        
+        Language(code: "Jobs", name: "Jobs"),
+        Language(code: "Hemingway", name: "Hemingway"),
     ]
     
     

--- a/Simpler/SimpleWords.swift
+++ b/Simpler/SimpleWords.swift
@@ -63,7 +63,11 @@ class SimpleWords: NSObject {
         self.languageCode = languageCode
         let fileName = getFilenameForLanguageCode(languageCode)
         
-        let path = NSBundle.mainBundle().pathForResource(fileName, ofType: "")!
+        guard let path = NSBundle.mainBundle().pathForResource(fileName, ofType: nil) else {
+            print("language not found")
+            return
+        }
+
         do {
             let text = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding)
             self.allWords = text.componentsSeparatedByString("\n")

--- a/Simpler/SimplerTextStorage.swift
+++ b/Simpler/SimplerTextStorage.swift
@@ -93,7 +93,7 @@ class SimplerTextStorage: NSTextStorage {
     }
     
     override func attributesAtIndex(location: Int, effectiveRange range: NSRangePointer) -> [String : AnyObject] {
-        return backingStore.attributesAtIndex(location, effectiveRange: range)
+        return location < backingStore.length ? backingStore.attributesAtIndex(location, effectiveRange: range) : [:]
    }
     
     override func replaceCharactersInRange(range: NSRange, withString str: String) {


### PR DESCRIPTION
v1.4 crashes when switching to "Jobs" or "Hemingway" languages. This is caused by the dictionary filename mismatching the language code. This change corrects the mismatch, and prevents the the app from crashing if a dictionary is not found.
